### PR TITLE
feature: name and bibstem data dump for autocompleteness 

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,6 +34,9 @@ NONINDEXED_FILE = '/non_indexed.txt'
 JOURNAL_ISSN_FILE = '/journal_issn'
 ISSN_JOURNAL_FILE = '/issn2journal'
 
+# Journal name data for nodejs autocomplete function
+JOURNALS_AUTOCOMPLETE_FILE = '/journals_autocomplete.json'
+
 # REFSOURCE_FILE
 BIB_TO_REFS_FILE = '/citing2file.dat'
 

--- a/journalsmanager/exceptions.py
+++ b/journalsmanager/exceptions.py
@@ -132,6 +132,10 @@ class ExportISSNException(Exception):
     pass
 
 
+class AutocompleteExportException(Exception):
+    pass
+
+
 class BackupFileException(Exception):
     pass
 

--- a/journalsmanager/tasks.py
+++ b/journalsmanager/tasks.py
@@ -660,7 +660,7 @@ def task_update_table(checkin, masterdict):
 def task_export_autocomplete_data():
     try:
         with app.session_scope() as session:
-            result = session.query(master.bibstem, master.journal_name, names.name_english_translated, names.name_native_language, names.name_normalized).outerjoin(master, master.masterid == names.masterid).order_by(master.bibstem.asc()).all()
+            result = session.query(master.bibstem, master.journal_name, names.name_english_translated, names.name_native_language, names.name_normalized).outerjoin(names, master.masterid == names.masterid).order_by(master.bibstem.asc()).all()
             # result = session.query(master.bibstem,master.pubtype,master.refereed,master.journal_name).filter_by(not_indexed=False).order_by(master.masterid.asc()).all()
             rows = []
             for r in result:

--- a/journalsmanager/tasks.py
+++ b/journalsmanager/tasks.py
@@ -663,12 +663,10 @@ def task_export_autocomplete_data():
             # result = session.query(master.bibstem,master.pubtype,master.refereed,master.journal_name).filter_by(not_indexed=False).order_by(master.masterid.asc()).all()
             rows = []
             for r in result:
-                (bibstem, name, translated_name, native_name,\
-                 transliterated_name) = r
-                rows.append({'bibstem': bibstem, 'name': name,
-                             'translated_name': translated_name,
-                             'native_name':native_name,
-                             'transliterated_name': transliterated_name})
+                rows.append({'bibstem': r['bibstem'], 'name': r['name'],
+                             'translated_name': r['translated_name'],
+                             'native_name':r['native_name'],
+                             'transliterated_name': r['transliterated_name']})
     except Exception as err:
         logger.error("Failed to query autocomplete data from tables: %s" % err)
     else:

--- a/journalsmanager/tasks.py
+++ b/journalsmanager/tasks.py
@@ -654,3 +654,26 @@ def task_update_table(checkin, masterdict):
 
     except Exception as err:
         raise UpdateTableException(err)
+
+@app.task(queue='load-datafiles')
+def task_export_autocomplete_data():
+    try:
+        with app.session_scope() as session:
+            result = session.query(master.bibstem, master.journal_name, names.name_english_translated, names.name_native_language, names.name_normalized).outerjoin(master, names.masterid == master.masterid).order_by(master.bibstem.asc()).all()
+            # result = session.query(master.bibstem,master.pubtype,master.refereed,master.journal_name).filter_by(not_indexed=False).order_by(master.masterid.asc()).all()
+            rows = []
+            for r in result:
+                (bibstem, name, translated_name, native_name,\
+                 transliterated_name) = r
+                rows.append({'bibstem': bibstem, 'name': name,
+                             'translated_name': translated_name,
+                             'native_name':native_name,
+                             'transliterated_name': transliterated_name})
+    except Exception as err:
+        logger.error("Failed to query autocomplete data from tables: %s" % err)
+    else:
+        try:
+            result_autocomplete = export_to_autocomplete(rows)
+        except Exception as err:
+            logger.error("Failed to export autocomplete data: %s" % err)
+

--- a/journalsmanager/tasks.py
+++ b/journalsmanager/tasks.py
@@ -671,7 +671,6 @@ def task_export_autocomplete_data():
     except Exception as err:
         logger.error("Failed to query autocomplete data from tables: %s" % err)
     else:
-        logger.warning("lol: %s" % str(rows[0:10]))
         try:
             result_autocomplete = export_to_autocomplete(rows)
         except Exception as err:

--- a/journalsmanager/tasks.py
+++ b/journalsmanager/tasks.py
@@ -660,7 +660,7 @@ def task_update_table(checkin, masterdict):
 def task_export_autocomplete_data():
     try:
         with app.session_scope() as session:
-            result = session.query(master.bibstem, master.journal_name, names.name_english_translated, names.name_native_language, names.name_normalized).outerjoin(master, names.masterid == master.masterid).order_by(master.bibstem.asc()).all()
+            result = session.query(master.bibstem, master.journal_name, names.name_english_translated, names.name_native_language, names.name_normalized).outerjoin(master, master.masterid == names.masterid).order_by(master.bibstem.asc()).all()
             # result = session.query(master.bibstem,master.pubtype,master.refereed,master.journal_name).filter_by(not_indexed=False).order_by(master.masterid.asc()).all()
             rows = []
             for r in result:
@@ -671,7 +671,7 @@ def task_export_autocomplete_data():
     except Exception as err:
         logger.error("Failed to query autocomplete data from tables: %s" % err)
     else:
-        logger.warning("lol: %s" % str(rows[0:5]))
+        logger.warning("lol: %s" % str(rows[0:10]))
         try:
             result_autocomplete = export_to_autocomplete(rows)
         except Exception as err:

--- a/journalsmanager/tasks.py
+++ b/journalsmanager/tasks.py
@@ -655,6 +655,7 @@ def task_update_table(checkin, masterdict):
     except Exception as err:
         raise UpdateTableException(err)
 
+
 @app.task(queue='load-datafiles')
 def task_export_autocomplete_data():
     try:
@@ -670,6 +671,7 @@ def task_export_autocomplete_data():
     except Exception as err:
         logger.error("Failed to query autocomplete data from tables: %s" % err)
     else:
+        logger.warning("lol: %s" % str(rows[0:5]))
         try:
             result_autocomplete = export_to_autocomplete(rows)
         except Exception as err:

--- a/journalsmanager/tasks.py
+++ b/journalsmanager/tasks.py
@@ -663,10 +663,10 @@ def task_export_autocomplete_data():
             # result = session.query(master.bibstem,master.pubtype,master.refereed,master.journal_name).filter_by(not_indexed=False).order_by(master.masterid.asc()).all()
             rows = []
             for r in result:
-                rows.append({'bibstem': r['bibstem'], 'name': r['name'],
-                             'translated_name': r['translated_name'],
-                             'native_name':r['native_name'],
-                             'transliterated_name': r['transliterated_name']})
+                rows.append({'bibstem': r[0], 'name': r[1],
+                             'translated_name': r[2],
+                             'native_name':r[3],
+                             'transliterated_name': r[4]})
     except Exception as err:
         logger.error("Failed to query autocomplete data from tables: %s" % err)
     else:

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -160,7 +160,7 @@ def export_to_autocomplete(rows):
                 data.append({'value': bibstem, 'label': names})
             elif not bibstem:
                 print('what the hell? %s' % str(r))
-        result = {'bibstem_journalname': data}
+        result = {'data': data}
         bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
         with open(bib2name_file, 'w') as fo:
             fo.write(json.dumps(result, indent=2))

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -155,7 +155,7 @@ def export_to_autocomplete(rows):
             for n in names:
                 if bibstem and n:
                     data.append({'value': bibstem, 'label': n})
-                else:
+                elif not bibstem:
                     print('what the hell? %s' % str(r))
         result = {'bibstem_journalname': data}
         bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -146,7 +146,7 @@ def export_to_autocomplete(rows):
     data = []
     try:
         for r in rows:
-            bibstem = r[bibstem]
+            bibstem = r['bibstem']
             names = list()
             names.append(r.get('name', None))
             names.append(r.get('translated_name', None))

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -146,15 +146,17 @@ def export_to_autocomplete(rows):
     data = []
     try:
         for r in rows:
-            bibstem = r['bibstem']
+            bibstem = r.get('bibstem', None)
             names = list()
             names.append(r.get('name', None))
             names.append(r.get('translated_name', None))
             names.append(r.get('native_name', None))
             names.append(r.get('transliterated_name', None))
             for n in names:
-                if n:
+                if bibstem and n:
                     data.append({'value': bibstem, 'label': n})
+                else:
+                    print('what the hell? %s' % str(r))
         result = {'bibstem_journalname': data}
         bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
         with open(bib2name_file, 'w') as fo:

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -152,11 +152,11 @@ def export_to_autocomplete(rows):
             names.append(r.get('translated_name', None))
             names.append(r.get('native_name', None))
             names.append(r.get('transliterated_name', None))
-            for n in names:
-                if bibstem and n:
-                    data.append({'value': bibstem, 'label': n})
-                elif not bibstem:
-                    print('what the hell? %s' % str(r))
+            filter(None, names)
+            if bibstem and names:
+                data.append({'value': bibstem, 'label': names})
+            elif not bibstem:
+                print('what the hell? %s' % str(r))
         result = {'bibstem_journalname': data}
         bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
         with open(bib2name_file, 'w') as fo:

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -163,7 +163,7 @@ def export_to_autocomplete(rows):
         result = {'data': data}
         bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
         with open(bib2name_file, 'w') as fo:
-            fo.write(json.dumps(result, indent=2))
+            fo.write(json.dumps(result))
     except Exception as err:
         raise AutocompleteExportException("Unable to export autocomplete json: %s" % err) 
             

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -148,11 +148,14 @@ def export_to_autocomplete(rows):
         for r in rows:
             bibstem = r.get('bibstem', None)
             names = list()
-            names.append(r.get('name', None))
-            names.append(r.get('translated_name', None))
-            names.append(r.get('native_name', None))
-            names.append(r.get('transliterated_name', None))
-            filter(None, names)
+            if r.get('name', None):
+                names.append(r.get('name', None))
+            if r.get('translated_name', None):
+                names.append(r.get('translated_name', None))
+            if r.get('native_name', None):
+                names.append(r.get('native_name', None))
+            if r.get('transliterated_name', None):
+                names.append(r.get('transliterated_name', None))
             if bibstem and names:
                 data.append({'value': bibstem, 'label': names})
             elif not bibstem:

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import chardet
 import csv
 import grp
+import json
 import pwd
 import os
 import requests
@@ -141,6 +142,26 @@ def export_issns(rows):
         else:
             return "Success: %s rows exported." % nrows
     
+def export_to_autocomplete(rows):
+    data = []
+    try:
+        for r in rows:
+            bibstem = r[bibstem]
+            names = list()
+            names.append(r.get('name', None))
+            names.append(r.get('translated_name', None))
+            names.append(r.get('native_name', None))
+            names.append(r.get('transliterated_name', None))
+            for n in names:
+                if n:
+                    data.append({'value': bibstem, 'label': n})
+        result = {'bibstem_journalname': data}
+        bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
+        with open(bib2name_file, 'w') as fo:
+            fo.write(json.dumps(result))
+    except Exception as err:
+        raise AutocompleteExportException("Unable to export autocomplete json: %s" % err) 
+            
 
 
 def read_abbreviations_list():

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -160,7 +160,7 @@ def export_to_autocomplete(rows):
         result = {'bibstem_journalname': data}
         bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
         with open(bib2name_file, 'w') as fo:
-            fo.write(json.dumps(result))
+            fo.write(json.dumps(result, indent=2))
     except Exception as err:
         raise AutocompleteExportException("Unable to export autocomplete json: %s" % err) 
             

--- a/run.py
+++ b/run.py
@@ -69,6 +69,13 @@ def get_arguments():
                         default=False,
                         help='Delete checked-in sheet from Google')
 
+    parser.add_argument('-ac',
+                        '--autocomplete-data',
+                        dest='autocomplete',
+                        action='store_true',
+                        default=False,
+                        help='Export journal name & bibstem data to json')
+
     args = parser.parse_args()
     return args
 
@@ -296,6 +303,9 @@ def main():
 
     elif args.dump_classic:
          tasks.task_export_classic_files()
+
+    elif args.autocomplete:
+         tasks.task_export_autocomplete_data()
 
     else:
         # These do require masterdict


### PR DESCRIPTION
The pipeline can now export a list of names (both canonical and translated/transliterated/native language when available) for use with the journals/bibstem autocomplete feature in the UI.

These data still need to be combined with any weights using holdings and/or citation data.