### PR TITLE
Revert editid

### DIFF
--- a/run.py
+++ b/run.py
@@ -83,6 +83,20 @@ def get_arguments():
                         default=None,
                         help='Undo edit # from editcontrol')
 
+    parser.add_argument('-cc',
+                        '--cancel-checkout',
+                        dest='cancelxo',
+                        action='store',
+                        default=None,
+                        help='Cancel active export id # from editcontrol')
+
+    parser.add_argument('-aa',
+                        '--abandon-all',
+                        dest='abandonall',
+                        action='store_true',
+                        default=False,
+                        help='Abandon all active sheet exports (use with caution -- this will abort **ALL** sheets currently being edited!)')
+
     args = parser.parse_args()
     return args
 
@@ -305,6 +319,9 @@ def main():
     if args.load_full:
         load_full_database()
 
+    elif args.abandonall:
+        tasks.task_abandon_active_checkouts()
+
     elif args.checkout_table:
         checkout_table(args.checkout_table)
 
@@ -316,6 +333,9 @@ def main():
 
     elif args.revertid:
         tasks.task_revert_editid(args.revertid)
+
+    elif args.cancelxo:
+        tasks.task_cancel_checkout(args.cancelxo)
 
     else:
         # These do require masterdict

--- a/run.py
+++ b/run.py
@@ -76,6 +76,13 @@ def get_arguments():
                         default=False,
                         help='Export journal name & bibstem data to json')
 
+    parser.add_argument('-re',
+                        '--revert-edit',
+                        dest='revertid',
+                        action='store',
+                        default=None,
+                        help='Undo edit # from editcontrol')
+
     args = parser.parse_args()
     return args
 
@@ -302,10 +309,13 @@ def main():
         checkout_table(args.checkout_table)
 
     elif args.dump_classic:
-         tasks.task_export_classic_files()
+        tasks.task_export_classic_files()
 
     elif args.autocomplete:
-         tasks.task_export_autocomplete_data()
+        tasks.task_export_autocomplete_data()
+
+    elif args.revertid:
+        tasks.task_revert_editid(args.revertid)
 
     else:
         # These do require masterdict


### PR DESCRIPTION
Adds code to: revert changes from a specific editid, to cancel a specific export checkout id, and to cancel all currently active exported sheets.