### PR TITLE
Added ranking to autocompletion data export

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,6 +37,10 @@ ISSN_JOURNAL_FILE = '/issn2journal'
 # Journal name data for nodejs autocomplete function
 JOURNALS_AUTOCOMPLETE_FILE = '/journals_autocomplete.json'
 
+# Backoffice ranking data files for nodejs autocomplete function
+CANONICAL_BIBS = '/canonical_bibcodes.current'
+CITATION_COUNTS = '/citation.counts'
+
 # REFSOURCE_FILE
 BIB_TO_REFS_FILE = '/citing2file.dat'
 

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -167,7 +167,7 @@ def export_to_autocomplete(rows):
         for r in rows:
             bibstem = r.get('bibstem', None)
             names = list()
-            bibcodeList = [c for c in canonicalBibs if b in c]
+            bibcodeList = [c for c in canonicalBibs if bibstem in c]
             bibcodeCount = len(bibcodeList)
             if bibcodeCount > 0:
                 citeSum = sum(cites.get(x, 0) for x in bibcodeList)

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -184,10 +184,14 @@ def export_to_autocomplete(rows):
                     names.append(r.get('transliterated_name', None))
                 if bibstem and names:
                     data.append({'value': bibstem, 'label': names, 'rank': rank})
+        # sort by rank, descending
         if data:
             sorted_data = sorted(data, key=itemgetter('rank'), reverse=True)
+
+        # remove rank entirely, and remove trailing dots from bibstem
         for d in sorted_data:
             del d['rank']
+            d['value'] = d['value'].rstrip('.')
 
         result = {'data': sorted_data}
         bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -184,7 +184,7 @@ def export_to_autocomplete(rows):
                     data.append({'value': bibstem, 'label': names, 'rank': rank})
         if data:
             sorted_data = sorted(data, key=itemgetter('rank'), reverse=True)
-            data = sorted_data
+        data = [d.pop('rank', None) for d in sorted_data]
         result = {'data': data}
         bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
         with open(bib2name_file, 'w') as fo:

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -184,8 +184,9 @@ def export_to_autocomplete(rows):
                     data.append({'value': bibstem, 'label': names, 'rank': rank})
         if data:
             sorted_data = sorted(data, key=itemgetter('rank'), reverse=True)
-        data = [d.pop('rank', None) for d in sorted_data]
-        result = {'data': data}
+        for d in sorted_data:
+            del d['rank']
+        result = {'data': sorted_data}
         bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
         with open(bib2name_file, 'w') as fo:
             fo.write(json.dumps(result))

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -166,6 +166,8 @@ def export_to_autocomplete(rows):
                         cites[bibcode] = (int(tcit) + int(rcit))
         for r in rows:
             bibstem = r.get('bibstem', None)
+            if len(bibstem) < 5:
+                bibstem = bibstem.ljust(5, '.')
             names = list()
             bibcodeList = [c for c in canonicalBibs if bibstem in c]
             bibcodeCount = len(bibcodeList)

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -175,13 +175,13 @@ def export_to_autocomplete(rows):
                 citeSum = sum(cites.get(x, 0) for x in bibcodeList)
                 rank = bibcodeCount + citeSum
                 if r.get('name', None):
-                    names.append(r.get('name', None))
+                    names.append(r['name'])
                 if r.get('translated_name', None):
-                    names.append(r.get('translated_name', None))
+                    names.append(r['translated_name'])
                 if r.get('native_name', None):
-                    names.append(r.get('native_name', None))
+                    names.append(r['native_name'])
                 if r.get('transliterated_name', None):
-                    names.append(r.get('transliterated_name', None))
+                    names.append(r['transliterated_name'])
                 if bibstem and names:
                     data.append({'value': bibstem, 'label': names, 'rank': rank})
         # sort by rank, descending

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -12,6 +12,7 @@ import urllib3
 from adsputils import load_config
 from bs4 import BeautifulSoup as bs
 from glob import glob
+from operator import itemgetter
 from journalsmanager.exceptions import *
 from journalsmanager.refsource import RefCount, RefVolume, RefSource
 
@@ -145,21 +146,45 @@ def export_issns(rows):
 def export_to_autocomplete(rows):
     data = []
     try:
+        canonicalBibs = []
+        bibcodeFile = config.get('CANONICAL_BIBS', None)
+        if bibcodeFile:
+            bibcodeFile = JDB_DATA_DIR + '/' + bibcodeFile
+            with open(bibcodeFile, 'r') as fb:
+                for l in fb.readlines():
+                    canonicalBibs.append(l.strip())
+        cites = {}
+        citationFile = config.get('CITATION_COUNTS', None)
+        if citationFile:
+            citationFile = JDB_DATA_DIR + '/' + citationFile
+            with open(citationFile, 'r') as fc:
+                for l in fc.readlines():
+                    (bibcode, tcit, rcit) = l.strip().split('\t')
+                    if cites.get(bibcode, None):
+                        cites[bibcode] += (int(tcit) + int(rcit))
+                    else:
+                        cites[bibcode] = (int(tcit) + int(rcit))
         for r in rows:
             bibstem = r.get('bibstem', None)
             names = list()
-            if r.get('name', None):
-                names.append(r.get('name', None))
-            if r.get('translated_name', None):
-                names.append(r.get('translated_name', None))
-            if r.get('native_name', None):
-                names.append(r.get('native_name', None))
-            if r.get('transliterated_name', None):
-                names.append(r.get('transliterated_name', None))
-            if bibstem and names:
-                data.append({'value': bibstem, 'label': names})
-            elif not bibstem:
-                print('what the hell? %s' % str(r))
+            bibcodeList = [c for c in canonicalBibs if b in c]
+            bibcodeCount = len(bibcodeList)
+            if bibcodeCount > 0:
+                citeSum = sum(cites.get(x, 0) for x in bibcodeList)
+                rank = bibcodeCount + citeSum
+                if r.get('name', None):
+                    names.append(r.get('name', None))
+                if r.get('translated_name', None):
+                    names.append(r.get('translated_name', None))
+                if r.get('native_name', None):
+                    names.append(r.get('native_name', None))
+                if r.get('transliterated_name', None):
+                    names.append(r.get('transliterated_name', None))
+                if bibstem and names:
+                    data.append({'value': bibstem, 'label': names, 'rank': rank})
+        if data:
+            sorted_data = sorted(data, key=itemgetter('rank'), reverse=True)
+            data = sorted_data
         result = {'data': data}
         bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
         with open(bib2name_file, 'w') as fo:
@@ -474,3 +499,5 @@ def backup_export_file(filepath, maxcount=3):
         raise BackupFileException(err)
 
     return
+
+

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -188,10 +188,16 @@ def export_to_autocomplete(rows):
             sorted_data = sorted(data, key=itemgetter('rank'), reverse=True)
         for d in sorted_data:
             del d['rank']
+
         result = {'data': sorted_data}
         bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
+
+        os.chmod(bib2name_file, 0o666)
         with open(bib2name_file, 'w') as fo:
             fo.write(json.dumps(result))
+        os.chmod(bib2name_file, 0o444)
+        chowner(bib2name_file)
+
     except Exception as err:
         raise AutocompleteExportException("Unable to export autocomplete json: %s" % err)
 


### PR DESCRIPTION
This adds functionality to the existing autocompletion data export that orders the output using our internal impact factor metric.  Ignores bibstems with no canonical bibcodes.