### PR TITLE
fix: slight adjustment to bibstem matching in autocompleteness data output

### DIFF
--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -169,7 +169,7 @@ def export_to_autocomplete(rows):
             if len(bibstem) < 5:
                 bibstem = bibstem.ljust(5, '.')
             names = list()
-            bibcodeList = [c for c in canonicalBibs if bibstem == c[4:9]]
+            bibcodeList = [c for c in canonicalBibs if (bibstem == c[4:9] or bibstem == c[4:13])]
             bibcodeCount = len(bibcodeList)
             if bibcodeCount > 0:
                 citeSum = sum(cites.get(x, 0) for x in bibcodeList)

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -169,7 +169,7 @@ def export_to_autocomplete(rows):
             if len(bibstem) < 5:
                 bibstem = bibstem.ljust(5, '.')
             names = list()
-            bibcodeList = [c for c in canonicalBibs if bibstem in c]
+            bibcodeList = [c for c in canonicalBibs if bibstem == c[4:9]]
             bibcodeCount = len(bibcodeList)
             if bibcodeCount > 0:
                 citeSum = sum(cites.get(x, 0) for x in bibcodeList)


### PR DESCRIPTION
We are now doing a list comprehension match of bibcodes to bibstems using an explicit match to bibcode[4:9] or bibcode[4:13].  Padding bibcodes with length less than 5 characters with '.' can still result in confusion of bibstems, e.g. 'RvA..' and 'PhRvA'.  Forcing the bibstem to exactly match characters 4-9 or 4-13 of the bibcode will fix this.