### PR TITLE
Completeness 2023 jan04

### DIFF
--- a/alembic/versions/8e37d049f5d2_mv_completeness_details_to_master.py
+++ b/alembic/versions/8e37d049f5d2_mv_completeness_details_to_master.py
@@ -1,0 +1,38 @@
+"""mv completeness details to master
+
+Revision ID: 8e37d049f5d2
+Revises: a19fb422743a
+Create Date: 2022-10-05 18:00:00.000000
+
+"""
+from alembic import op
+from adsputils import UTCDateTime, get_date
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '8e37d049f5d2'
+down_revision = 'a19fb422743a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    for table in ['master', 'master_hist']:
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.add_column(sa.Column('completeness_details', sa.Text()))
+
+    for table in ['titlehistory', 'titlehistory_hist']:
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.drop_column(column_name='completeness_details')
+
+def downgrade():
+
+    for table in ['titlehistory', 'titlehistory_hist']:
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.add_column(sa.Column('completeness_details', sa.Text()))
+
+    for table in ['master', 'master_hist']:
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.drop_column(column_name='completeness_details')

--- a/config.py
+++ b/config.py
@@ -47,6 +47,10 @@ BIB_TO_REFS_FILE = '/citing2file.dat'
 # RASTERIZING.xml directory
 RASTER_CONFIG_DIR = '/raster_config/'
 
+# Completeness statistics from completeness_statistics_pipeline
+COMPLETENESS_JSON_FILE = '/completeness_export.json'
+COMPLETENESS_CRIT_VALUE = 0.95
+
 #------------------------------------------------------
 
 '''

--- a/journalsdb/models.py
+++ b/journalsdb/models.py
@@ -27,6 +27,7 @@ class JournalsMaster(Base):
     refereed = Column(ref_status, nullable=False)
     collection = Column(String, nullable=True)
     completeness_fraction = Column(String, nullable=True)
+    completeness_details = Column(Text)
     notes = Column(Text)
     not_indexed = Column(Boolean, default=False)
     created = Column(UTCDateTime, default=get_date)
@@ -45,6 +46,7 @@ class JournalsMaster(Base):
                 'refereed': self.refereed,
                 'collection': self.collection,
                 'completeness_fraction': self.completeness_fraction,
+                'completeness_details': self.completeness_details,
                 'notes': self.notes,
                 'not_indexed': self.not_indexed}
 
@@ -65,6 +67,7 @@ class JournalsMasterHistory(Base):
     refereed = Column(String)
     collection = Column(String)
     completeness_fraction = Column(String)
+    completeness_details = Column(Text)
     notes = Column(Text)
     not_indexed = Column(Boolean)
     created = Column(UTCDateTime)
@@ -253,7 +256,6 @@ class JournalsTitleHistory(Base):
     year_end = Column(Integer)
     vol_start = Column(String)
     vol_end = Column(String)
-    completeness_details = Column(Text)
     publisherid = Column(Integer, ForeignKey('publisher.publisherid'))
     successor_masterid = Column(Integer)
     notes = Column(Text)
@@ -268,7 +270,6 @@ class JournalsTitleHistory(Base):
                 'year_end': self.year_end,
                 'vol_start': self.vol_start,
                 'vol_end': self.vol_end,
-                'completeness_details': self.completeness_details,
                 'publisherid': self.publisherid,
                 'successor_masterid': self.successor_masterid,
                 'notes': self.notes}
@@ -285,7 +286,6 @@ class JournalsTitleHistoryHistory(Base):
     year_end = Column(Integer)
     vol_start = Column(String)
     vol_end = Column(String)
-    completeness_details = Column(Text)
     publisherid = Column(Integer)
     successor_masterid = Column(Integer)
     notes = Column(Text)

--- a/journalsmanager/exceptions.py
+++ b/journalsmanager/exceptions.py
@@ -142,3 +142,7 @@ class BackupFileException(Exception):
 
 class FileOwnershipError(Exception):
     pass
+
+
+class LoadCompletenessDataException(Exception)
+    pass

--- a/journalsmanager/exceptions.py
+++ b/journalsmanager/exceptions.py
@@ -144,5 +144,5 @@ class FileOwnershipError(Exception):
     pass
 
 
-class LoadCompletenessDataException(Exception)
+class LoadCompletenessDataException(Exception):
     pass

--- a/journalsmanager/tasks.py
+++ b/journalsmanager/tasks.py
@@ -38,18 +38,18 @@ TABLES = {'master': master, 'master_hist': master_hist,
           'titlehistory': titlehistory, 'titlehistory_hist': titlehistory_hist,
           'refsource': refsource, 'rastervol': rastervol}
 
-TABLE_UNIQID = {'master': 'masterid', 
-                'names': 'nameid', 
-                'abbrevs': 'abbrevid', 
-                'idents': 'identid', 
-                'publisher': 'publisherid', 
-                'titlehistory': 'titlehistoryid', 
-                'raster': 'rasterid', 
+TABLE_UNIQID = {'master': 'masterid',
+                'names': 'nameid',
+                'abbrevs': 'abbrevid',
+                'idents': 'identid',
+                'publisher': 'publisherid',
+                'titlehistory': 'titlehistoryid',
+                'raster': 'rasterid',
                 'rastervol': 'rvolid'}
 
 proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../'))
 
-app = app_module.ADSJournalsCelery('journals', proj_home=proj_home, 
+app = app_module.ADSJournalsCelery('journals', proj_home=proj_home,
                                    config=globals().get('config', {}),
                                    local_config=globals().get('local_config', {}))
 logger = app.logger

--- a/journalsmanager/tasks.py
+++ b/journalsmanager/tasks.py
@@ -38,11 +38,20 @@ TABLES = {'master': master, 'master_hist': master_hist,
           'titlehistory': titlehistory, 'titlehistory_hist': titlehistory_hist,
           'refsource': refsource, 'rastervol': rastervol}
 
-TABLE_UNIQID = {'master': 'masterid', 'names': 'nameid', 'abbrevs': 'abbrevid', 'idents': 'identid', 'publisher': 'publisherid', 'titlehistory': 'titlehistoryid', 'raster': 'rasterid', 'rastervol': 'rvolid'}
+TABLE_UNIQID = {'master': 'masterid', 
+                'names': 'nameid', 
+                'abbrevs': 'abbrevid', 
+                'idents': 'identid', 
+                'publisher': 'publisherid', 
+                'titlehistory': 'titlehistoryid', 
+                'raster': 'rasterid', 
+                'rastervol': 'rvolid'}
 
 proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../'))
 
-app = app_module.ADSJournalsCelery('journals', proj_home=proj_home, config=globals().get('config', {}), local_config=globals().get('local_config', {}))
+app = app_module.ADSJournalsCelery('journals', proj_home=proj_home, 
+                                   config=globals().get('config', {}),
+                                   local_config=globals().get('local_config', {}))
 logger = app.logger
 
 app.conf.CELERY_QUEUES = (
@@ -92,10 +101,13 @@ def task_db_bibstems_to_master(recs):
                         rtype = reftypes[r[1]]
                     else:
                         rtype = 'na'
-                    session.add(master(bibstem=r[0], journal_name=r[2],
-                                               primary_language='en',
-                                               pubtype=ptype, refereed=rtype,
-                                               defunct=False, not_indexed=False))
+                    session.add(master(bibstem=r[0],
+                                       journal_name=r[2],
+                                       primary_language='en',
+                                       pubtype=ptype,
+                                       refereed=rtype,
+                                       defunct=False,
+                                       not_indexed=False))
                 else:
                     logger.debug("task_db_bibstems_to_master: Bibstem %s already in master", r[0])
             try:
@@ -147,7 +159,7 @@ def task_db_load_abbrevs(recs):
             for r in recs:
                 try:
                     session.add(abbrevs(masterid=r[0],
-                                                      abbreviation=r[1]))
+                                        abbreviation=r[1]))
                     session.commit()
                 except Exception as err:
                     logger.debug("Problem with abbreviation: %s,%s" %
@@ -338,7 +350,7 @@ def task_db_load_refsource(masterid, refsrc):
             try:
                 refsrc = json.dumps(refsrc.toJSON())
                 session.add(refsource(masterid=masterid,
-                                              refsource_list=refsrc))
+                                      refsource_list=refsrc))
                 session.commit()
             except Exception as err:
                 logger.warning("Error adding refsources for %s: %s" %
@@ -355,8 +367,10 @@ def task_db_insert_nonindexed_bibstems(nonindexed_dict):
     with app.session_scope() as session:
         for k, v in nonindexed_dict.items():
             try:
-                session.add(master(bibstem=k, journal_name=v['name'],
-                                   pubtype='Other', refereed='na',
+                session.add(master(bibstem=k,
+                                   journal_name=v['name'],
+                                   pubtype='Other',
+                                   refereed='na',
                                    not_indexed=True))
                 session.commit()
             except Exception as err:
@@ -446,18 +460,31 @@ def task_checkout_table(tablename, results):
             table_record = session.query(editctrl).filter(editctrl.tablename.ilike(tablename), editctrl.editstatus=='active').first()
 
             if table_record:
-                sheet = SpreadsheetManager(creds=app.conf.CREDENTIALS_FILE, token=app.conf.TOKEN_FILE, folderid=app.conf.HOME_FOLDER_ID, editors=app.conf.EDITORS, sheetid=table_record.editfileid)
+                sheet = SpreadsheetManager(creds=app.conf.CREDENTIALS_FILE,
+                                           token=app.conf.TOKEN_FILE,
+                                           folderid=app.conf.HOME_FOLDER_ID,
+                                           editors=app.conf.EDITORS,
+                                           sheetid=table_record.editfileid)
                 logger.debug("Table %s is already checked out: Time: %s, ID: %s" % (tablename, table_record.created, table_record.editfileid))
 
             else:
-                sheet = SpreadsheetManager(creds=app.conf.CREDENTIALS_FILE, token=app.conf.TOKEN_FILE, folderid=app.conf.HOME_FOLDER_ID, editors=app.conf.EDITORS)
-                sheet.create_sheet(title=tablename, folderid=app.conf.HOME_FOLDER_ID)
-                session.add(editctrl(tablename=tablename, editstatus='active', editfileid=sheet.sheetid))
+                sheet = SpreadsheetManager(creds=app.conf.CREDENTIALS_FILE,
+                                           token=app.conf.TOKEN_FILE,
+                                           folderid=app.conf.HOME_FOLDER_ID,
+                                           editors=app.conf.EDITORS)
+                sheet.create_sheet(title=tablename,
+                                   folderid=app.conf.HOME_FOLDER_ID)
+                session.add(editctrl(tablename=tablename,
+                                     editstatus='active',
+                                     editfileid=sheet.sheetid))
                 session.commit()
 
                 try:
                     data = task_export_table_data(tablename, results)
-                    sheet.write_table(sheetid=sheet.sheetid, data=data, tablename=tablename, encoding='utf-8')
+                    sheet.write_table(sheetid=sheet.sheetid,
+                                      data=data,
+                                      tablename=tablename,
+                                      encoding='utf-8')
                 except Exception as err:
                     raise WriteDataToSheetException(err)
             try:
@@ -482,7 +509,11 @@ def task_checkin_table(tablename, masterdict, delete_flag=False):
             table_record = session.query(editctrl).filter(editctrl.tablename.ilike(tablename), editctrl.editstatus=='active').first()
 
             if table_record:
-                sheet = SpreadsheetManager(creds=app.conf.CREDENTIALS_FILE, token=app.conf.TOKEN_FILE, folderid=app.conf.HOME_FOLDER_ID, editors=app.conf.EDITORS, sheetid=table_record.editfileid)
+                sheet = SpreadsheetManager(creds=app.conf.CREDENTIALS_FILE,
+                                           token=app.conf.TOKEN_FILE,
+                                           folderid=app.conf.HOME_FOLDER_ID,
+                                           editors=app.conf.EDITORS,
+                                           sheetid=table_record.editfileid)
                 logger.debug("Table %s is currently checked out: Time: %s, ID: %s" % (tablename, table_record.created, table_record.editfileid))
 
                 data = sheet.fetch_table()
@@ -739,8 +770,8 @@ def task_abandon_active_checkouts():
 
 def task_load_completeness_data():
     try:
-        infile = app.conf.COMPLETENESS_JSON_FILE
-        critc = app.conf.COMPLETENESS_CRIT_VALUE
+        infile = app.conf.get('JDB_DATA_DIR', '/') + app.conf.get('COMPLETENESS_JSON_FILE', '/error.dat')
+        critc = app.conf.get('COMPLETENESS_CRIT_VALUE', 0.95)
         with open(infile, 'r') as fj:
             completeness_data = json.load(fj)
     except Exception as err:
@@ -750,11 +781,17 @@ def task_load_completeness_data():
             fraction = d.get('completeness_fraction', 0)
             bibstem = d.get('bibstem', None)
             details = json.dumps(d.get('completeness_details', '{}'))
-            if frac >= critc:
+            if fraction >= critc:
                 try:
                     with app.session_scope() as session:
-                        result = session.execute(update(master).where(master.bibstem==bibstem).values(completeness_fraction=fraction, completeness_details=details))
-                        session.commit()
+                        q = session.query(master).filter(master.bibstem==bibstem).all()
+                        if len(q) != 1:
+                            logger.warn("Error: There should be exactly one record that matches the bibstem '%s' in master, not %s!" % (bibstem, len(q)))
+                        else:
+                            r = q[0]
+                            setattr(r, 'completeness_fraction', fraction)
+                            setattr(r, 'completeness_details', details)
+                            session.commit()
                 except Exception as err:
                     session.rollback()
                     session.flush()

--- a/journalsmanager/utils.py
+++ b/journalsmanager/utils.py
@@ -64,7 +64,7 @@ def get_encoding(filename):
 
 def read_bibstems_list():
     data = {}
-    infile = JDB_DATA_DIR + '/bibstems.dat'
+    infile = JDB_DATA_DIR + '/' + config.get('BIBSTEMS_FILE', 'error.file')
     try:
         with open(infile, 'r', encoding=get_encoding(infile)) as f:
             nbibstem = f.readline()
@@ -84,7 +84,7 @@ def read_bibstems_list():
 def export_to_bibstemsdat(rows):
     if rows:
         try:
-            outfile = JDB_DATA_DIR + config.get('BIBSTEMS_FILE', 'error.file')
+            outfile = JDB_DATA_DIR + '/' + config.get('BIBSTEMS_FILE', 'error.file')
             backup_export_file(outfile)
         except Exception as err:
             ExportBibstemsException(err)
@@ -119,8 +119,8 @@ def export_to_bibstemsdat(rows):
 
 
 def export_issns(rows):
-    i2j_file = JDB_DATA_DIR + config.get('ISSN_JOURNAL_FILE', 'error.file')
-    j2i_file = JDB_DATA_DIR + config.get('JOURNAL_ISSN_FILE', 'error.file')
+    i2j_file = JDB_DATA_DIR + '/' + config.get('ISSN_JOURNAL_FILE', 'error.file')
+    j2i_file = JDB_DATA_DIR + '/' + config.get('JOURNAL_ISSN_FILE', 'error.file')
     if rows:
         nrows = str(len(rows))
         try:
@@ -194,7 +194,7 @@ def export_to_autocomplete(rows):
             d['value'] = d['value'].rstrip('.')
 
         result = {'data': sorted_data}
-        bib2name_file = JDB_DATA_DIR + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
+        bib2name_file = JDB_DATA_DIR + '/' + config.get('JOURNALS_AUTOCOMPLETE_FILE', 'error.file')
 
         os.chmod(bib2name_file, 0o666)
         with open(bib2name_file, 'w') as fo:
@@ -254,7 +254,7 @@ def read_issn_files():
 def read_complete_csvs():
     data = {}
     for coll in config.get('COLLECTIONS'):
-        infile = JDB_DATA_DIR + '/completion.' + coll + '.csv'
+        infile = JDB_DATA_DIR + '/' + 'completion.' + coll + '.csv'
         if os.path.exists(infile):
             try:
                 with open(infile, 'r', encoding=get_encoding(infile)) as f:
@@ -512,5 +512,3 @@ def backup_export_file(filepath, maxcount=3):
         raise BackupFileException(err)
 
     return
-
-

--- a/run.py
+++ b/run.py
@@ -42,6 +42,12 @@ def get_arguments():
                         action='store_true',
                         help='Load refsources from citing2file.dat')
 
+    parser.add_argument('-lc',
+                        '--load-completeness',
+                        dest='load_completeness',
+                        action='store_true',
+                        help='Load completeness data')
+
     parser.add_argument('-dc',
                         '--dump-classic-files',
                         dest='dump_classic',
@@ -167,7 +173,7 @@ def load_abbreviations(masterdict):
     return
 
 
-def load_completeness(masterdict):
+def load_completeness_old(masterdict):
     '''
     Completeness loads multiple tables: publisher, idents, titlehistory
     '''
@@ -299,7 +305,7 @@ def load_full_database():
         logger.warning("Error loading master table: %s" % err)
     else:
         try:
-            load_completeness(masterdict)
+            load_completeness_old(masterdict)
             load_abbreviations(masterdict)
             load_rasterconfig(masterdict)
             load_refsources(masterdict)
@@ -367,6 +373,12 @@ def main():
                     logger.warning("Error clearing refsource table: %s" % err)
                 else:
                     load_refsources(masterdict)
+
+            elif args.load_completeness:
+                try:
+                    tasks.task_load_completeness_data()
+                except Exception as err:
+                    logger.error("Unable to load completeness data: %s" % err)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR moves the completeness details field from the TitleHistory table to Master, and adds a task to read and insert JSON output from ADSCompStat.

The default threshold for completeness data to be added to the table is 0.95, meaning we would only add completeness data to master if we are complete at the 95% level or better.  We may want to lower or eliminate this threshold when matching for special cases is improved in ADSCompStat, and/or if we want to use ADSJournalsDB as a curation tool to improve coverage.