### PR TITLE
New ISSN search endpoint (Fulfills Issue #53)

### DIFF
--- a/journalsservice/app.py
+++ b/journalsservice/app.py
@@ -24,6 +24,7 @@ def create_app(**config):
     api.add_resource(Journal, '/journal/<string:journalname>')
     api.add_resource(Holdings, '/holdings/<string:bibstem>/<string:volume>')
     api.add_resource(Refsource, '/refsource/<string:bibstem>')
+    api.add_resource(ISSN, '/issn/<string:issn>')
 
     discoverer = Discoverer(app)
 

--- a/journalsservice/app.py
+++ b/journalsservice/app.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from werkzeug.serving import run_simple
-from .views import Summary, Journal, Holdings, Refsource
+from .views import Summary, Journal, Holdings, Refsource, ISSN
 from flask_restful import Api
 from flask_discoverer import Discoverer
 from adsmutils import ADSFlask

--- a/journalsservice/views.py
+++ b/journalsservice/views.py
@@ -9,7 +9,7 @@ from dateutil import parser
 from journalsdb.models import JournalsMaster, JournalsAbbreviations, JournalsIdentifiers, JournalsPublisher, JournalsRefSource, JournalsTitleHistory, JournalsNames
 from journalsservice.adsquery import ADSQuery
 import adsmutils
-from sqlalchemy import or_
+from sqlalchemy import or_, like
 
 def liken(text):
     text_out = re.sub(r'[. ]{1,}', '%', text)
@@ -165,8 +165,9 @@ class ISSN(Resource):
                 if len(issn) == 8:
                     issn = issn[0:4] + "-" + issn[4:]
                 with current_app.session_scope() as session:
-                    dat_idents = session.query(JournalsIdentifiers).filter_by(id_value=issn).first()
+                    dat_idents = session.query(JournalsIdentifiers).filter(idents.id_type.like('ISSN_%'), idents.id_value==issn).first()
                     masterid = dat_idents.masterid
+                    id_value = dat_idents.id_value
                     id_type = dat_idents.id_type
                     if masterid:
                         dat_master = session.query(JournalsMaster).filter_by(masterid=masterid).first()

--- a/journalsservice/views.py
+++ b/journalsservice/views.py
@@ -9,7 +9,7 @@ from dateutil import parser
 from journalsdb.models import JournalsMaster, JournalsAbbreviations, JournalsIdentifiers, JournalsPublisher, JournalsRefSource, JournalsTitleHistory, JournalsNames
 from journalsservice.adsquery import ADSQuery
 import adsmutils
-from sqlalchemy import or_, like
+from sqlalchemy import or_, and_
 
 def liken(text):
     text_out = re.sub(r'[. ]{1,}', '%', text)
@@ -165,7 +165,7 @@ class ISSN(Resource):
                 if len(issn) == 8:
                     issn = issn[0:4] + "-" + issn[4:]
                 with current_app.session_scope() as session:
-                    dat_idents = session.query(JournalsIdentifiers).filter(idents.id_type.like('ISSN_%'), idents.id_value==issn).first()
+                    dat_idents = session.query(JournalsIdentifiers).filter(and_(JournalsIdentifiers.id_value==issn, JournalsIdentifiers.id_type.like("ISSN%"))).first()
                     masterid = dat_idents.masterid
                     id_value = dat_idents.id_value
                     id_type = dat_idents.id_type

--- a/journalsservice/views.py
+++ b/journalsservice/views.py
@@ -166,10 +166,10 @@ class ISSN(Resource):
                     issn = issn[0:4] + "-" + issn[4:]
                 with current_app.session_scope() as session:
                     dat_idents = session.query(JournalsIdentifiers).filter(and_(JournalsIdentifiers.id_value==issn, JournalsIdentifiers.id_type.like("ISSN%"))).first()
-                    masterid = dat_idents.masterid
-                    id_value = dat_idents.id_value
-                    id_type = dat_idents.id_type
-                    if masterid:
+                    if dat_idents:
+                        masterid = dat_idents.masterid
+                        id_value = dat_idents.id_value
+                        id_type = dat_idents.id_type
                         dat_master = session.query(JournalsMaster).filter_by(masterid=masterid).first()
                         bibstem = dat_master.bibstem
                         journal_name = dat_master.journal_name

--- a/journalsservice/views.py
+++ b/journalsservice/views.py
@@ -167,11 +167,13 @@ class ISSN(Resource):
                 with current_app.session_scope() as session:
                     dat_idents = session.query(JournalsIdentifiers).filter_by(id_value=issn).first()
                     masterid = dat_idents.masterid
+                    id_type = dat_idents.id_type
                     if masterid:
                         dat_master = session.query(JournalsMaster).filter_by(masterid=masterid).first()
                         bibstem = dat_master.bibstem
                         journal_name = dat_master.journal_name
-                        result = {'ISSN': issn,
+                        result = {'ISSN': id_value,
+                                  'ISSN_type': id_type,
                                   'bibstem': bibstem,
                                   'journal_name': journal_name}
             except Exception as err:

--- a/journalsservice/views.py
+++ b/journalsservice/views.py
@@ -151,3 +151,30 @@ class Refsource(Resource):
                         'Error Info': 'Unspecified error.  Try again.'}, 500
         return {'refsource': request_json}, 200
 
+
+class ISSN(Resource):
+
+    scopes = []
+    rate_limit = [1000, 60 * 60 * 24]
+    decorators = [advertise('scopes', 'rate_limit')]
+
+    def get(self, issn):
+        result = {}
+        if issn:
+            try:
+                if len(issn) == 8:
+                    issn = issn[0:4] + "-" + issn[4:]
+                with current_app.session_scope() as session:
+                    dat_idents = session.query(JournalsIdentifiers).filter_by(id_value=issn).first()
+                    masterid = dat_idents.masterid
+                    if masterid:
+                        dat_master = session.query(JournalsMaster).filter_by(masterid=masterid).first()
+                        bibstem = dat_master.bibstem
+                        journal_name = dat_master.journal_name
+                        result = {'ISSN': issn,
+                                  'bibstem': bibstem,
+                                  'journal_name': journal_name}
+            except Exception as err:
+                return {'Error': 'Refsource search failed',
+                        'Error Info': 'Unspecified error.  Try again.'}, 500
+        return result, 200

--- a/journalsservice/views.py
+++ b/journalsservice/views.py
@@ -58,7 +58,7 @@ class Summary(Resource):
                         return result_json, 200
             except Exception as err:
                 return {'Error': 'Summary search failed',
-                        'Error Info': 'Unspecified error.  Try again.'}, 500
+                        'Error Info': str(err)}, 500
         else:
             result_json = {'summary': {}}
             return result_json, 200
@@ -92,7 +92,7 @@ class Journal(Resource):
                         journal_list.append({"bibstem": dat_master.bibstem, "name": dat_master.journal_name})
             except Exception as err:
                 return {'Error': 'Journal search failed',
-                        'Error Info': 'Unspecified error.  Try again.'}, 500
+                        'Error Info': str(err)}, 500
 
         result_json = {'journal': journal_list}
         return result_json, 200
@@ -119,7 +119,7 @@ class Holdings(Resource):
                       'holdings': holdings}
         except Exception as err:
             return {'Error': 'Holdings search failed',
-                    'Error Info': 'Unspecified error.  Try again.'}, 500
+                    'Error Info': str(err)}, 500
         else:
             return result, 200
 
@@ -148,7 +148,7 @@ class Refsource(Resource):
                         request_json = json.loads(dat_refsource.refsource_list)
             except Exception as err:
                 return {'Error': 'Refsource search failed',
-                        'Error Info': 'Unspecified error.  Try again.'}, 500
+                        'Error Info': str(err)}, 500
         return {'refsource': request_json}, 200
 
 
@@ -178,7 +178,7 @@ class ISSN(Resource):
                                                 'bibstem': bibstem,
                                                 'journal_name': journal_name}}
             except Exception as err:
-                return {'Error': 'Refsource search failed',
+                return {'Error': 'issn search failed',
                         'Error Info': str(err)}, 500
         else:
             request_json = {'issn': {}}

--- a/journalsservice/views.py
+++ b/journalsservice/views.py
@@ -179,7 +179,7 @@ class ISSN(Resource):
                                                 'journal_name': journal_name}}
             except Exception as err:
                 return {'Error': 'Refsource search failed',
-                        'Error Info': 'Unspecified error.  Try again.'}, 500
+                        'Error Info': str(err)}, 500
         else:
             request_json = {'issn': {}}
         return request_json, 200

--- a/journalsservice/views.py
+++ b/journalsservice/views.py
@@ -159,7 +159,7 @@ class ISSN(Resource):
     decorators = [advertise('scopes', 'rate_limit')]
 
     def get(self, issn):
-        result = {}
+        request_json = {}
         if issn:
             try:
                 if len(issn) == 8:
@@ -173,11 +173,13 @@ class ISSN(Resource):
                         dat_master = session.query(JournalsMaster).filter_by(masterid=masterid).first()
                         bibstem = dat_master.bibstem
                         journal_name = dat_master.journal_name
-                        result = {'ISSN': id_value,
-                                  'ISSN_type': id_type,
-                                  'bibstem': bibstem,
-                                  'journal_name': journal_name}
+                        request_json = {'issn': {'ISSN': id_value,
+                                                'ISSN_type': id_type,
+                                                'bibstem': bibstem,
+                                                'journal_name': journal_name}}
             except Exception as err:
                 return {'Error': 'Refsource search failed',
                         'Error Info': 'Unspecified error.  Try again.'}, 500
-        return result, 200
+        else:
+            request_json = {'issn': {}}
+        return request_json, 200


### PR DESCRIPTION
This PR adds a new endpoint ("issn") to the journals API as requested (Issue #53  ).  It will search journals.idents for rows having an id_value matching the user input, and an id_type like ("ISSN%").  If the user-entered issn string is not found in the idents table, it will return an empty dict ({}). 