### PR TITLE
Canonical abbrev.20240826

### DIFF
--- a/alembic/versions/d8e9edc2c0e8_canonical_abbreviation.py
+++ b/alembic/versions/d8e9edc2c0e8_canonical_abbreviation.py
@@ -21,11 +21,11 @@ def upgrade():
 
     for table in ['abbrevs', 'abbrevs_hist']:
         with op.batch_alter_table(table) as batch_op:
-            batch_op.add_column(sa.Column('canonical', sa.Boolean()))
+            batch_op.add_column(sa.Column('canonical', sa.Boolean(), default=False))
 
 def downgrade():
 
     for table in ['abbrevs', 'abbrevs_hist']:
         with op.batch_alter_table(table) as batch_op:
-            batch_op.add_column(sa.Column('canonical', sa.Boolean()))
+            batch_op.drop_column(column_name='canonical')
 

--- a/alembic/versions/d8e9edc2c0e8_canonical_abbreviation.py
+++ b/alembic/versions/d8e9edc2c0e8_canonical_abbreviation.py
@@ -1,0 +1,31 @@
+"""create canonical column in abbrevs
+
+Revision ID: d8e9edc2c0e8
+Revises: 8e37d049f5d2
+Create Date: 2022-10-05 18:00:00.000000
+
+"""
+from alembic import op
+from adsputils import UTCDateTime, get_date
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'd8e9edc2c0e8'
+down_revision = '8e37d049f5d2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    for table in ['abbrevs', 'abbrevs_hist']:
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.add_column(sa.Column('canonical', sa.Boolean()))
+
+def downgrade():
+
+    for table in ['abbrevs', 'abbrevs_hist']:
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.add_column(sa.Column('canonical', sa.Boolean()))
+

--- a/journalsdb/models.py
+++ b/journalsdb/models.py
@@ -130,6 +130,7 @@ class JournalsAbbreviations(Base):
     masterid = Column(Integer, ForeignKey('master.masterid'),
                       primary_key=True, nullable=False)
     abbreviation = Column(String)
+    canonical = Column(Boolean, default=False, nullable=False)
     created = Column(UTCDateTime, default=get_date)
     updated = Column(UTCDateTime, onupdate=get_date)
 
@@ -149,6 +150,7 @@ class JournalsAbbreviationsHistory(Base):
     abbrevid = Column(Integer)
     masterid = Column(Integer)
     abbreviation = Column(String)
+    canonical = Column(Boolean)
     created = Column(UTCDateTime)
     updated = Column(UTCDateTime)
     superseded = Column(UTCDateTime, default=get_date)

--- a/journalsmanager/tasks.py
+++ b/journalsmanager/tasks.py
@@ -442,9 +442,9 @@ def task_export_table_data(tablename, results):
                     results = session.query(idents.identid, idents.masterid, master.bibstem, idents.id_type, idents.id_value).join(master, idents.masterid == master.masterid).order_by(idents.masterid.asc()).all()
 
             elif tablename == 'abbrevs':
-                csvout.writerow(('abbrevid','masterid','bibstem','abbreviation'))
+                csvout.writerow(('abbrevid','masterid','bibstem','abbreviation','canonical'))
                 if not results:
-                    results = session.query(abbrevs.abbrevid, abbrevs.masterid, master.bibstem, abbrevs.abbreviation).join(master, abbrevs.masterid == master.masterid).order_by(abbrevs.masterid.asc()).all()
+                    results = session.query(abbrevs.abbrevid, abbrevs.masterid, master.bibstem, abbrevs.abbreviation, abbrevs.canonical).join(master, abbrevs.masterid == master.masterid).order_by(abbrevs.masterid.asc()).all()
 
             elif tablename == 'publisher':
                 csvout.writerow(('publisherid','pubabbrev','pubaddress','pubcontact','puburl','pubextid','pubfullname', 'notes'))


### PR DESCRIPTION
This revision adds the boolean column `canonical` to the `abbrevs` and `abbrevs_hist` tables.  These will be used by the curators to define a canonical abbreviation with len(abbrev)<=16 characters.